### PR TITLE
Add benchmarking utilities

### DIFF
--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -18,7 +18,7 @@ JSLIB =		wast.js
 WINMAKE =	winmake.bat
 
 DIRS =		util syntax binary text valid runtime exec script host main tests verified verified_wrapper verified_wrapper/pbytes
-LIBS =		bigarray
+LIBS =		bigarray unix
 PKGS =		zarith
 FLAGS = 	-use-ocamlfind -lexflags -ml -cflags '-w +a-3-4-8-11-20-26-27-32-39-42-44-45-70 -warn-error -unboxed-types'
 OCBA =		ocamlbuild $(FLAGS) $(DIRS:%=-I %) $(PKGS:%=-pkgs %)

--- a/interpreter/host/env.ml
+++ b/interpreter/host/env.ml
@@ -38,9 +38,13 @@ let abort vs =
 let exit vs =
   exit (int (single vs))
 
+let clock_ms vs =
+    let seconds = Unix.gettimeofday () in
+    [Num (I64Num.to_num (Int64.of_float (seconds *. 1000.)))]
 
 let lookup name t =
   match Utf8.encode name, t with
   | "abort", ExternFuncType t -> ExternFunc (Func.alloc_host t abort)
   | "exit", ExternFuncType t -> ExternFunc (Func.alloc_host t exit)
+  | "clock_ms", ExternFuncType (FuncType ([], [NumType I64Type])) -> ExternFunc (Func.alloc_host (FuncType ([], [NumType I64Type])) clock_ms)
   | _ -> raise Not_found

--- a/interpreter/host/env_isa.ml
+++ b/interpreter/host/env_isa.ml
@@ -1,0 +1,33 @@
+(*
+ * Utilities for test cases and benchmarking
+ *)
+
+ open WasmRef_Isa.WasmRef_Isa
+ 
+ let clock_ms' vs =
+   let seconds = Unix.gettimeofday () in
+   let milliseconds = (Int64.of_float (seconds *. 1000.)) in
+   [V_num (ConstInt64 (I64_impl_abs milliseconds))]
+ 
+ let clock_ms' : host =
+   Host_func (Abs_host_func (fun (s, vs) -> Some (s, clock_ms' vs)))
+ 
+  let env_func_imports =
+   [
+    ("clock_ms", Func_host (Tf ([],[T_num T_i64]), clock_ms'))
+   ]
+ 
+let install_env_funcs (s : unit s_ext) : (unit s_ext * ((string * v_ext) list)) =
+   match s with
+   | (S_ext (cls, tabs, mems, globs, elems, datas, _)) ->
+     let cl_n = List.length cls in
+     let (env_names, spectest_cls) = List.split env_func_imports in
+     let exp_list = List.mapi (fun i name -> (name, Ext_func (Nat (Z.of_int (cl_n + i))))) env_names in
+     (S_ext (cls@spectest_cls, tabs, mems, globs, elems, datas, ()), exp_list)
+ 
+ let install_env_isa (s : unit s_ext) : (unit s_ext * ((string * v_ext) list)) =
+   match s with
+   | S_ext (cls, tabs, mems, globs, elems, datas, _) ->
+     let (s', exp_funcs) = install_env_funcs s in
+     (s', exp_funcs)
+ 

--- a/interpreter/host/env_isa.ml
+++ b/interpreter/host/env_isa.ml
@@ -4,13 +4,13 @@
 
  open WasmRef_Isa.WasmRef_Isa
  
- let clock_ms' vs =
+ let clock_ms vs =
    let seconds = Unix.gettimeofday () in
    let milliseconds = (Int64.of_float (seconds *. 1000.)) in
    [V_num (ConstInt64 (I64_impl_abs milliseconds))]
  
  let clock_ms' : host =
-   Host_func (Abs_host_func (fun (s, vs) -> Some (s, clock_ms' vs)))
+   Host_func (Abs_host_func (fun (s, vs) -> Some (s, clock_ms vs)))
  
   let env_func_imports =
    [

--- a/interpreter/host/spectest_isa.ml
+++ b/interpreter/host/spectest_isa.ml
@@ -14,10 +14,8 @@ let print_value (v : v) =
   let v' = Ast_convert.convert_value_rev v in
   print_value' v'
 
-(* let print' : host =
-  Abs_host_m (fun (s, vs) -> fun () -> List.iter print_value vs; flush_all (); Some (s, [])) *)
-  let print' : host =
-    Host_func (Abs_host_func (fun (s, vs) -> List.iter print_value vs; flush_all (); Some (s, [])))
+let print' : host =
+  Host_func (Abs_host_func (fun (s, vs) -> List.iter print_value vs; flush_all (); Some (s, [])))
 
 let spectest_func_imports =
  [("print", Func_host (Tf ([],[]), print'));
@@ -29,16 +27,10 @@ let spectest_func_imports =
   ("print_f64_f64", Func_host (Tf ([T_num T_f64; T_num T_f64],[]), print'))
  ]
 
-(* let spectest_tab_imports =
- [("table", (Array.make 10 None, Some (Nat (Z.of_int 20))))
- ] *)
 let spectest_tab_imports =
  [("table", ((T_tab (Limit_t_ext (Nat (Z.of_int 10), Some (Nat (Z.of_int 20)), ()), T_func_ref)), Lib.List.make 10 ((ConstNull T_func_ref)) ))
  ]
 
-(* let spectest_mem_imports =
- [("memory", (new_zeroed_byte_array (Nat (Z.of_int 65536)) (), Some (Nat (Z.of_int 2))))
- ] *)
  let spectest_mem_imports =
   [("memory", (Limit_t_ext (Nat (Z.of_int 1), Some (Nat (Z.of_int 2)), ()), (Pbytes.make 65536 (isabelle_byte_to_ocaml_char zero_byte))))
   ]
@@ -55,7 +47,7 @@ let spectest_glob_imports =
   | (S_ext (cls, tabs, mems, globs, elems, datas, _)) ->
     let cl_n = List.length cls in
     let (spectest_names, spectest_cls) = List.split spectest_func_imports in
-    let exp_list = List.mapi (fun i name -> (name, Ext_func (Nat (Z.of_int i)))) spectest_names in
+    let exp_list = List.mapi (fun i name -> (name, Ext_func (Nat (Z.of_int (cl_n + i))))) spectest_names in
     (S_ext (cls@spectest_cls, tabs, mems, globs, elems, datas, ()), exp_list)
 
 let install_spectest_tabs (s : unit s_ext) : (unit s_ext * ((string * v_ext) list)) =
@@ -63,7 +55,7 @@ let install_spectest_tabs (s : unit s_ext) : (unit s_ext * ((string * v_ext) lis
   | (S_ext (cls, tabs, mems, globs, elems, datas,_)) ->
     let tab_n = List.length tabs in
     let (spectest_names, spectest_tabs) = List.split spectest_tab_imports in
-    let exp_list = List.mapi (fun i name -> (name, Ext_tab (Nat (Z.of_int i)))) spectest_names in
+    let exp_list = List.mapi (fun i name -> (name, Ext_tab (Nat (Z.of_int (tab_n + i))))) spectest_names in
     (S_ext (cls, tabs@spectest_tabs, mems, globs, elems, datas,()), exp_list)
 
 let install_spectest_mems (s : unit s_ext) : (unit s_ext * ((string * v_ext) list)) =
@@ -71,7 +63,7 @@ let install_spectest_mems (s : unit s_ext) : (unit s_ext * ((string * v_ext) lis
   | (S_ext (cls, tabs, mems, globs, elems, datas,_)) ->
     let mem_n = List.length mems in
     let (spectest_names, spectest_mems) = List.split spectest_mem_imports in
-    let exp_list = List.mapi (fun i name -> (name, Ext_mem (Nat (Z.of_int i)))) spectest_names in
+    let exp_list = List.mapi (fun i name -> (name, Ext_mem (Nat (Z.of_int (mem_n + i))))) spectest_names in
     (S_ext (cls, tabs, mems@spectest_mems, globs, elems, datas,()), exp_list)
 
 let install_spectest_globs (s : unit s_ext) : (unit s_ext * ((string * v_ext) list)) =
@@ -79,7 +71,7 @@ let install_spectest_globs (s : unit s_ext) : (unit s_ext * ((string * v_ext) li
   | (S_ext (cls, tabs, mems, globs, elems, datas, _)) ->
     let glob_n = List.length globs in
     let (spectest_names, spectest_globs) = List.split spectest_glob_imports in
-    let exp_list = List.mapi (fun i name -> (name, Ext_glob (Nat (Z.of_int i)))) spectest_names in
+    let exp_list = List.mapi (fun i name -> (name, Ext_glob (Nat (Z.of_int (glob_n + i))))) spectest_names in
     (S_ext (cls, tabs, mems, globs@spectest_globs, elems, datas, ()), exp_list)
 
 let install_spectest_isa (s : unit s_ext) : (unit s_ext * ((string * v_ext) list)) =

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -307,12 +307,14 @@ let registry : Instance.module_inst Map.t ref = ref Map.empty
 
 let exports_isa : ((string * WasmRef_Isa.v_ext) list) Map_isa.t ref = ref Map_isa.empty
 
-(* let store_isa = ref (WasmRef_Isa.make_empty_store_m ()) *)
 let store_isa = ref (WasmRef_Isa.S_ext ([],[],[],[],[],[],()))
 
 let configure_isa () =
   let (s', spectest_exports) = Spectest_isa.install_spectest_isa !store_isa in
-  store_isa := s'; exports_isa := Map_isa.add "spectest" spectest_exports !exports_isa
+  let (s'', env_exports) = Env_isa.install_env_isa s' in
+  store_isa := s'';
+  exports_isa := Map_isa.add "spectest" spectest_exports !exports_isa;
+  exports_isa := Map_isa.add "env" env_exports !exports_isa
 
 let m_name_isa x_opt =
   match x_opt with
@@ -328,7 +330,7 @@ let match_import_isa (m_imp : 'a WasmRef_Isa.module_import_ext) : WasmRef_Isa.v_
   match m_imp with
   | WasmRef_Isa.Module_import_ext (m_str, imp_str, _, _) ->
     try find_export_isa m_str imp_str with
-    | e -> trace ("(Isabelle) error matching import " ^ m_str ^ " " ^ imp_str); raise (Import.Unknown(no_region, "(Isabelle) unknown import"))
+    | e -> trace ("(Isabelle) error matching import " ^ m_str ^ " " ^ imp_str); raise (Import.Unknown(no_region, "(Isabelle) unknown import: " ^ m_str ^ " " ^ imp_str))
 
 let bind map x_opt y =
   let map' =


### PR DESCRIPTION
Add `env.clock_ms()` function that is used by the `coremark-wasm` benchmark.